### PR TITLE
Fix for python 3.10+

### DIFF
--- a/lazylist.py
+++ b/lazylist.py
@@ -1,10 +1,16 @@
 import collections
 
+try:
+    from collections import Sequence
+except ImportError:
+    # >=Python 3.10
+    from collections.abc import Sequence
+
 __all__ = 'LazyList',
 __version__ = '0.9.1'
 
 
-class LazyList(collections.Sequence):
+class LazyList(Sequence):
     """An immutable proxy sequence to a given ``view_function``."""
 
     def __init__(self, view_function):
@@ -15,7 +21,7 @@ class LazyList(collections.Sequence):
     @property
     def raw_value(self):
         result = self.view_function()
-        if not isinstance(result, collections.Sequence):
+        if not isinstance(result, Sequence):
             raise TypeError(repr(result) + ' is not a sequence')
         return result
 


### PR DESCRIPTION
python 3.10 error

```
    from lazylist import LazyList
  File "/home/user/.pyenv/versions/3.10.6/envs/veems/lib/python3.10/site-packages/lazylist.py", line 7, in <module>
    class LazyList(collections.Sequence):
AttributeError: module 'collections' has no attribute 'Sequence'
```